### PR TITLE
deseq columns getting mislabeled

### DIFF
--- a/Examples/Run_gsea_ex1.r
+++ b/Examples/Run_gsea_ex1.r
@@ -38,7 +38,8 @@ gsea_ex1 <- function(DE_out_path = NULL, export_path = NULL,
       myClass <- useIDmappingFile(myClass=myClass,
                                   geneMapTable=geneMapTable)
     }
-    colnames(myClass) <- c("log2FoldChange","AveExpr","t","P.Value","padj","B","gene_name")
+    
+	# colnames(myClass) <- c("baseMean","log2FoldChange","lfcSE","stat","p","padj","gene_name")
     
     #DEGTable <- subset(myClass, abs(log2FoldChange) >= .58 & (padj < 0.05) )
     DEGTable <- subset(myClass, (padj < 0.05) )


### PR DESCRIPTION
Example code tries to set labels for the deseq output but:

1. The column names are not in the right order (should be "baseMean","log2FoldChange","lfcSE","stat","p","padj") so code as is sorts and passes in the baseMean column as log2foldchange

and 

2. Assumes that the gene_name will be the final column.

The column names seem to already be being read in fine without needing to manually set them.